### PR TITLE
100x more lines

### DIFF
--- a/src/Abunplot.f
+++ b/src/Abunplot.f
@@ -10,8 +10,9 @@ c******************************************************************************
       include 'Linex.com'
       include 'Pstuff.com'
       include 'Dummy.com'
-      real*4 ep(2500),abb(2500),logrw(2500),wavepl(2500)
-      equivalence (ep,dummy3(1)),(abb,dummy3(1251)),(logrw,dummy3(2501))
+      real*4 ep(250000),abb(250000),logrw(250000),wavepl(250000)
+      equivalence (ep,dummy3(1)),(abb,dummy3(125001)),
+     .            (logrw,dummy3(250001))
       real*4 style(1),ymed
       character ion*4
 

--- a/src/Equivs.com
+++ b/src/Equivs.com
@@ -9,16 +9,16 @@ c     for synthetic spectra may be accomplished without allocating
 c     large amounts of additional memory for the code.
 c******************************************************************************
 
-      real*4      chunk(100000,5)
+      real*4      chunk(10000000,5)
       equivalence (chunk(1,1),a(1,1)),  
      .            (chunk(1,2),a(1,21)),
      .            (chunk(1,3),a(1,41)), 
      .            (chunk(1,4),a(1,61)),
      .            (chunk(1,5),a(1,81))
 
-      real*4      xsyn(100000), dev(100000)
+      real*4      xsyn(10000000), dev(10000000)
       equivalence (xsyn,kapnu0(1,1)), (dev,kapnu0(1,21))
 
-      real*4      y(100000), z(100000)
+      real*4      y(10000000), z(10000000)
       equivalence (y,kapnu0(1,41)), (z,kapnu0(1,61))
 

--- a/src/Inlines.f
+++ b/src/Inlines.f
@@ -103,7 +103,7 @@ c*****read in the strong lines if needed
          endif
       endif
 
-340   nlines = 2500 - nstrong
+340   nlines = 250000 - nstrong
       j = 1
 333   if (linfileopt .eq. 0) then
          read (nflines,1002,end=311) wave1(j),atom1(j),e(j,1),gf(j),
@@ -253,7 +253,7 @@ c*****here are the calculations specific to atomic lines
 
 
 c*****quit the routine normally
-      if (nlines+nstrong .lt. 2500) then
+      if (nlines+nstrong .lt. 250000) then
          if (sstop .gt. wave1(nlines)+10.) sstop = wave1(nlines)+10.
       endif
       lim1line = 1
@@ -293,6 +293,5 @@ c*****format statements
       
 
       end
-
 
 

--- a/src/Linex.com
+++ b/src/Linex.com
@@ -8,13 +8,13 @@ c     "kapnu0" are often over-written with plotting data,
 c     so leave them alone or suffer unspeakable programming tortures.
 c******************************************************************************
 
-      real*8       a(2500,100), dopp(2500,100), kapnu0(2500,100)
-      real*8       gf(2500), wave1(2500), atom1(2500), e(2500,2),
-     .             chi(2500,3), amass(2500), charge(2500), d0(2500),
-     .             dampnum(2500), gf1(2500), width(2500), 
-     .             abundout(2500), widout(2500), strength(2500), 
-     .             rdmass(2500), gambark(2500), alpbark(2500),
-     .             wid1comp(2500)
+      real*8       a(250000,100), dopp(250000,100), kapnu0(250000,100)
+      real*8       gf(250000), wave1(250000), atom1(250000), e(250000,2),
+     .             chi(250000,3), amass(250000), charge(250000), d0(250000),
+     .             dampnum(250000), gf1(250000), width(250000), 
+     .             abundout(250000), widout(250000), strength(250000), 
+     .             rdmass(250000), gambark(250000), alpbark(250000),
+     .             wid1comp(250000)
       real*8       kapnu(100), taunu(100), cd(100), sline(100)
       real*8       d(5000), dellam(400), w(100),
      .             rwtab(3000), gftab(3000), gfhold
@@ -24,9 +24,9 @@ c******************************************************************************
      .             delwave, wave, waveold, st1
       real*8       gammatot, gammav, gammas, gammar
       integer      lim1, lim2, mode, ndepths, ncurve, nlines,nstrong,
-     .             lim1line, lim2line, ntabtot, group(2500),
+     .             lim1line, lim2line, ntabtot, group(250000),
      .             iabatom, molflag, dostrong, gfstyle
-      character*7  damptype(2500)
+      character*7  damptype(250000)
 
       common/linex/a, dopp, kapnu0,   
      .             gf, wave1, atom1, e,

--- a/src/Linlimit.f
+++ b/src/Linlimit.f
@@ -79,7 +79,7 @@ c     wavelength step; called from "synspec"
                return
             endif
          enddo   
-         if (nlines+nstrong .eq. 2500) then
+         if (nlines+nstrong .eq. 250000) then
             lim2line = -1
          else
             lim2line = nlines

--- a/src/Weedout.f
+++ b/src/Weedout.f
@@ -125,7 +125,7 @@ c*****divide the lines into keepers and discards
             endif
          endif
       enddo
-      if (nlines +nstrong .eq. 2500) then
+      if (nlines +nstrong .eq. 250000) then
          call inlines (6)
          go to 1
       endif


### PR DESCRIPTION
"Vanilla" moog can only handle linelists containing up to 2500 lines, insufficient for the dense molecular forests in the near- and mid-infrared.  This patch is a working example that allows 'synth' mode to be run on much larger linelists, up to 100x longer (i.e. 250 000 lines).  It's a start!